### PR TITLE
feat: set mt executor to use 3 threads only

### DIFF
--- a/launch/state_monitor.launch.py
+++ b/launch/state_monitor.launch.py
@@ -245,7 +245,7 @@ def generate_launch_description():
         composable_node_descriptions=[state_monitor_node],
         parameters=[
             {'use_intra_process_comms': True},
-            {'thread_num': os.cpu_count()},
+            {'thread_num': 3},
             {'use_sim_time': use_sim_time},
         ],
         condition=IfCondition(standalone)


### PR DESCRIPTION
This pull request makes a small configuration change to the `state_monitor.launch.py` launch file by setting the number of threads used by the state monitor node to a fixed value.

* The `thread_num` parameter is now set to `3` instead of dynamically using the number of CPUs (`os.cpu_count()`).