### PR TITLE
feat: use EventsCBGExecutor with two threads

### DIFF
--- a/launch/state_monitor.launch.py
+++ b/launch/state_monitor.launch.py
@@ -238,14 +238,14 @@ def generate_launch_description():
         namespace=robot_name,
         name=namespace + '_container',
         package='rclcpp_components',
-        executable='component_container_mt',
+        executable='component_container_events_cbg',
         output="screen",
         arguments=['--ros-args', '--log-level', LaunchConfiguration('log_level')],
         # prefix=['debug_roslaunch ' + os.ttyname(sys.stdout.fileno())],
         composable_node_descriptions=[state_monitor_node],
         parameters=[
             {'use_intra_process_comms': True},
-            {'thread_num': 3},
+            {'thread_num': 2},
             {'use_sim_time': use_sim_time},
         ],
         condition=IfCondition(standalone)


### PR DESCRIPTION
This pull request makes a small update to the `state_monitor.launch.py` launch file, changing the container executable and adjusting the state monitor's threading configuration.

- Changed the `executable` from `component_container_mt` to `component_container_events_cbg` to use a different ROS 2 component container implementation.
- Reduced the `thread_num` parameter from 3 to 2, likely to optimize resource usage or adapt to the new container's requirements.

Tested in the simulation.