### PR TITLE
feat: set subscription for mass_nomial for latched subsciption

### DIFF
--- a/src/state_monitor.cpp
+++ b/src/state_monitor.cpp
@@ -199,7 +199,12 @@ void StateMonitor::initialize() {
   ph_uav_info_      = mrs_lib::PublisherHandler<mrs_msgs::msg::UavInfo>(node_, "~/uav_info_out");
   sh_hw_api_status_ = mrs_lib::SubscriberHandler<mrs_msgs::msg::HwApiStatus>(shopts, "~/hw_api_status_in");
   sh_tracker_cmd_   = mrs_lib::SubscriberHandler<mrs_msgs::msg::TrackerCommand>(shopts, "~/tracker_cmd_in");
-  sh_mass_nominal_  = mrs_lib::SubscriberHandler<std_msgs::msg::Float64>(shopts, "~/mass_nominal_in");
+  {
+    // control_manager publishes mass_nominal once, latched (transient_local); match its QoS here
+    mrs_lib::SubscriberHandlerOptions shopts_mass_nominal = shopts;
+    shopts_mass_nominal.qos                               = rclcpp::QoS(1).transient_local();
+    sh_mass_nominal_                                      = mrs_lib::SubscriberHandler<std_msgs::msg::Float64>(shopts_mass_nominal, "~/mass_nominal_in");
+  }
   sh_mass_estimate_ = mrs_lib::SubscriberHandler<std_msgs::msg::Float64>(shopts, "~/mass_estimate_in");
 
   // | -------- Acquisition utils ------ |
@@ -294,9 +299,14 @@ void StateMonitor::timerMain() {
   const auto hw_api_mag_heading             = processIncomingMessage(sh_hw_api_mag_heading_);
   const auto hw_api_status                  = processIncomingMessage(sh_hw_api_status_);
   const auto mass_estimate                  = processIncomingMessage(sh_mass_estimate_);
-  const auto mass_nominal                   = processIncomingMessage(sh_mass_nominal_);
   const auto mpc_tracker_diagnostics        = processIncomingMessage(sh_mpc_tracker_diagnostics_);
   const auto tracker_cmd                    = processIncomingMessage(sh_tracker_cmd_);
+
+  // mass_nominal is published once, latched
+  // Once received, treat it as valid indefinitely instead.
+  subscriptionResult_t<std_msgs::msg::Float64> mass_nominal;
+  mass_nominal.hasNewMessage = sh_mass_nominal_.newMsg();
+  mass_nominal.message = mass_nominal.hasNewMessage ? sh_mass_nominal_.getMsg() : sh_mass_nominal_.peekMsg();
 
   // Watt-hour integration on each new battery sample.
   if (battery_state.hasNewMessage && battery_state.message != nullptr)
@@ -348,7 +358,7 @@ void StateMonitor::timerMain() {
   ph_uav_state_.publish(uav_state_msg);
 
   // to avoid getting timeout warnings on this latched message
-  if (sh_mass_nominal_.hasMsg())
+  if (mass_nominal.hasNewMessage)
     sh_mass_nominal_.setNoMessageTimeout(mrs_lib::no_timeout);
 }
 


### PR DESCRIPTION
## Summary

-  **What changed**:
Subscriber for `mass_nominal_out` topic updated to use `TRANSIENT_LOCAL` durability `QoS`.
-  **Why**:
`ControlManager` now publishes `mass_nominal_out` as a latched topic (TRANSIENT_LOCAL QoS). Subscribers with the default `VOLATILE` durability will not receive the retained message on connect, causing the nominal mass to be unavailable until the next publish cycle. This update makes mrs_robot_diagnostics compatible.
-  **Notes for reviewers**:
Depends on https://github.com/ctu-mrs/mrs_uav_managers/pull/41. The subscriber QoS must match or be compatible — TRANSIENT_LOCAL on the subscriber side ensures the retained value is received immediately on connection.

## Impact

-  **Affected areas**: `mass_nominal_out` subscriber
-  **Breaking changes**: No

## Testing status

-  **What was tested**:
  * [x] Build/test passes
  * [ ] Tests updated if needed
  * [x] Tested in simulation
  * [ ] Tested on real HW
  
- **How to repeat tests**:
 run the system with new mrs_uav_status.